### PR TITLE
Windows send UDP packet to ip address it recieved on

### DIFF
--- a/install_scripts/install_udp_rx.sh
+++ b/install_scripts/install_udp_rx.sh
@@ -78,7 +78,8 @@ echo "Installing the service"
 cp udp_rx.service /lib/systemd/system
 chmod 644 /lib/systemd/system/udp_rx.service
 systemctl daemon-reload
+systemctl enable udp_rx.service
 echo "udp_rx service is installed."
 echo "place keys into /etc/udp_rx or change the default configuration found in /etc/udp_rx/udp_rx_conf.json"
 echo "Run systemctl start udp_rx.service after the keys are installed"
-#systemctl start name.service 
+#systemctl start name.service

--- a/udp_rx_cert_creator/udp_rx_cert_creator.go
+++ b/udp_rx_cert_creator/udp_rx_cert_creator.go
@@ -1,8 +1,22 @@
 package main
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
 	"flag"
+	"io/ioutil"
 	"log"
+	"math/big"
+	"net"
+	"strings"
+	"time"
 
 	certcreator "../cert_creator"
 )
@@ -13,13 +27,151 @@ func main() {
 	caKeyPasswordFlag := flag.String("keypass", "", "password for private key if encrypted")
 	caCertPathFlag := flag.String("certpath", "./ca.crt", "path to the certfile")
 	// device key output
-	deviceKeyFlag := flag.String("devkey", "/etc/udp_rx/udp_rx.key", "The output path for the udp_rx device key")
-	deviceCertFlag := flag.String("devcert", "/etc/udp_rx/udp_rx.crt", "The oputput path for the udp_rx device cert")
+	deviceKeyFlag := flag.String("devkey", "udp_rx.key", "The output path for the udp_rx device key")
+	deviceCertFlag := flag.String("devcert", "udp_rx.crt", "The oputput path for the udp_rx device cert")
+	//specify ip to build for
+	ipFlag := flag.String("ips", "", "A comma separated string of IP addresses. If not set, it will use this systems IP addresses")
 	// parse args
 	flag.Parse()
 	// create the certs
-	err := certcreator.CreateCert(*deviceCertFlag, *deviceKeyFlag, *caKeyPathFlag, *caCertPathFlag, *caKeyPasswordFlag)
-	if err != nil {
-		log.Panic("Error create a key and certificate. Error: ", err.Error())
+	//err := certcreator.CreateCert(*deviceCertFlag, *deviceKeyFlag, *caKeyPathFlag, *caCertPathFlag, *caKeyPasswordFlag)
+	if *ipFlag != "" {
+		//parse the ip addresses into strings
+		ips := strings.Split(*ipFlag, ",")
+		caCert, err := ioutil.ReadFile(*caCertPathFlag)
+		caKey, err := ioutil.ReadFile(*caKeyPathFlag)
+		caCertString := string(caCert)
+		caKeyString := string(caKey)
+		parsedDkr := deviceKeyRequest{
+			Ips:       ips,
+			Hostnames: []string{},
+			CaCert:    caCertString,
+			CaKey:     caKeyString,
+			StartTime: time.Now(),
+		}
+		dkr, err := generateDeviceKeyPair(parsedDkr)
+		if err != nil {
+			log.Panic("Error create a key and certificate. Error: ", err.Error())
+		}
+		err = ioutil.WriteFile(*deviceKeyFlag, []byte(dkr.DeviceKey), 0666)
+		err = ioutil.WriteFile(*deviceCertFlag, []byte(dkr.DeviceCert), 0666)
+		if err != nil {
+			log.Panic("Error writing key and cert files. Error: ", err.Error())
+		}
+	} else {
+		err := certcreator.CreateCert(*deviceCertFlag, *deviceKeyFlag, *caKeyPathFlag, *caCertPathFlag, *caKeyPasswordFlag)
+		if err != nil {
+			log.Panic("Error create a key and certificate. Error: ", err.Error())
+		}
 	}
+}
+
+func generateDeviceKeyPair(dkr deviceKeyRequest) (deviceKeyResponse, error) {
+	//parse the IPs
+	var ips []net.IP
+	for _, ipstring := range dkr.Ips {
+		parsedip := net.ParseIP(ipstring)
+		if parsedip != nil {
+			ips = append(ips, parsedip)
+		}
+	}
+	//create a new private key
+	newPrivKey := createPrivateKeyInMemory()
+	//load the certificate authority certificate
+	caCertBlock, _ := pem.Decode([]byte(dkr.CaCert))
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return deviceKeyResponse{}, err
+	}
+	//load the certificate authority private key
+	caKeyBlock, _ := pem.Decode([]byte(dkr.CaKey))
+	caKey, _, err := parsePrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return deviceKeyResponse{}, err
+	}
+	//get the public key from the private key
+	_, pubkey, err := parsePrivateKey(newPrivKey)
+	if err != nil {
+		return deviceKeyResponse{}, err
+	}
+	//create the new certificate which will be signed by the CA
+	newCert := &x509.Certificate{
+		SerialNumber: big.NewInt(1653),
+		Subject: pkix.Name{
+			Organization:  []string{"Otis Elevator"},
+			Country:       []string{"US"},
+			Province:      []string{"Connecticut"},
+			Locality:      []string{"Farmington"},
+			StreetAddress: []string{"5 Farm Springs"},
+			PostalCode:    []string{"06032"},
+		},
+		NotBefore:             dkr.StartTime,
+		NotAfter:              dkr.StartTime.AddDate(100, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IPAddresses:           ips,
+		DNSNames:              dkr.Hostnames,
+	}
+	var newCertB []byte
+	newCertB, err = x509.CreateCertificate(
+		rand.Reader, //rand reader
+		newCert,     //cert we're going to sign
+		caCert,      //the CA's cert
+		pubkey,      //the pubkey of the new cert
+		caKey)       //the priv key of the CA
+	if err != nil {
+		return deviceKeyResponse{}, err
+	}
+	newCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: newCertB})
+	newKeyPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: newPrivKey})
+	return deviceKeyResponse{DeviceCert: string(newCertPem), DeviceKey: string(newKeyPem)}, nil
+}
+func parsePrivateKey(der []byte) (crypto.PrivateKey, crypto.PublicKey, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, &key.PublicKey, nil
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		switch key := key.(type) {
+		case *rsa.PrivateKey:
+			return key, &key.PublicKey, nil
+		case *ecdsa.PrivateKey:
+			return key, &key.PublicKey, nil
+		default:
+			return nil, nil, errors.New("tls: found unknown private key type in PKCS#8 wrapping")
+		}
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, &key.PublicKey, nil
+	}
+
+	return nil, nil, errors.New("tls: failed to parse private key")
+}
+func createPrivateKeyInMemory() []byte {
+	//if the file doesn't exist:
+	//log.Debug("Creating new private key")
+	genPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatal("Couldn't generate private key", err)
+	}
+	marshaledKey, err := x509.MarshalECPrivateKey(genPrivKey)
+	if err != nil {
+		log.Fatal("Couldn't marshal private key", err)
+	}
+	return marshaledKey
+}
+
+type deviceKeyRequest struct {
+	Ips       []string
+	Hostnames []string
+	CaCert    string
+	CaKey     string
+	StartTime time.Time
+}
+
+// DeviceKeyResponse is the response to a DeviceKeyRequest
+type deviceKeyResponse struct {
+	DeviceKey  string
+	DeviceCert string
 }

--- a/udprx_firewall/udprx_setfirewall.go
+++ b/udprx_firewall/udprx_setfirewall.go
@@ -66,4 +66,10 @@ func main() {
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)
 	}
+	if *unsetFlag {
+		log.Print("udprx_firewall - Unset firewall")
+	} else {
+		log.Print("udprx_firewall - set firewall")
+	}
+
 }

--- a/udprxlib/win_send_udp.go
+++ b/udprxlib/win_send_udp.go
@@ -43,7 +43,7 @@ func SendUDP(srcipstr string, destipstr string, srcprt uint, destprt uint, data 
 		return err
 	}
 	//dial and connect to localhost
-	ServerAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", destprt))
+	ServerAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", destipstr, destprt))
 	if err != nil {
 		log.Error("Error resolving localhost - this should never happen")
 		return err


### PR DESCRIPTION
Windows should send UDP packets to the interface it received the TLS connection on, as opposed to localhost (127.0.0.1)