### PR TITLE
Add client hostname validation

### DIFF
--- a/header_format.md
+++ b/header_format.md
@@ -5,7 +5,7 @@ The current header version is:
 
 `1.0.0`
 
-This section will be updated on new releases of udp_rx and is up to date as of version A23.
+This section will be updated on new releases of udp_rx and is up to date as of version A24.
 
 
 ## Description

--- a/udp_rx.go
+++ b/udp_rx.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is a constant that is this verion of the code, according to OTIS standards
-const Version = "A2331825AAA"
+const Version = "A2431825AAA"
 
 // RemoteTLSPort is the port of the remote TLS server (also the port of the local TLS server)
 const RemoteTLSPort = ":55554"

--- a/udp_rx.go
+++ b/udp_rx.go
@@ -61,7 +61,7 @@ func main() {
 	}
 	// get and parse command line args
 	versionFlag := flag.Bool("version", false, "Print the Version number and exit")
-	logFlag := flag.Int("loglevel", 0, "level of logging. 0 is warn+, 1 is Info+, 2 is debug+")
+	logFlag := flag.Int("loglevel", 2, "level of logging. 0 is warn+, 1 is Info+, 2 is debug+")
 	listenAddrFlag := flag.String("bindaddr", defaultListenAddr, "The IP address to bind the listening UDP socket to")
 	cpuprofileFlag := flag.String("cpuprofile", "", "If specified writed a cpuprofile to the given filename")
 	maxProfilingPacketsFlag := flag.Int("maxprofpackets", 1000, "the maximum number of packets allowed to be forwarded during CPU profiling")
@@ -141,12 +141,7 @@ func main() {
 		RootCAs:      rootCAs,
 		Certificates: []tls.Certificate{cer},
 	}
-	serverConf = &tls.Config{
-		Certificates: []tls.Certificate{cer},
-		MinVersion:   tls.VersionTLS12,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    rootCAs,
-	}
+	serverConf = udprxlib.GetServerConfig(rootCAs, cer)
 
 	// start listening on the UDP port in go routine
 	udpListenerDone := make(chan error, 1)
@@ -213,10 +208,14 @@ func setConfigValues(conf *udprxlib.ConfFile, listAddrArg, keyPathArg, certPathA
 }
 
 func modifyDefaultsWindows() {
-	confFilePath = "c:\\programdata\\udp_rx\\udp_rx_conf.windows.json"
-	defaultKeyPath = "c:\\programdata\\udp_rx\\udp_rx.key"
-	defaultCertPath = "c:\\programdata\\udp_rx\\udp_rx.crt"
-	defaultCACertPath = "c:\\programdata\\udp_rx\\ca.crt"
+	// confFilePath = "c:\\programdata\\udp_rx\\udp_rx_conf.windows.json"
+	// defaultKeyPath = "c:\\programdata\\udp_rx\\udp_rx.key"
+	// defaultCertPath = "c:\\programdata\\udp_rx\\udp_rx.crt"
+	// defaultCACertPath = "c:\\programdata\\udp_rx\\ca.crt"
+	confFilePath = "C:\\Users\\jeremymill\\Documents\\temp\\udp_rx_conf.windows.json"
+	defaultKeyPath = "C:\\Users\\jeremymill\\Documents\\temp\\udp_rx.key"
+	defaultCertPath = "C:\\Users\\jeremymill\\Documents\\temp\\udp_rx.crt"
+	defaultCACertPath = "C:\\Users\\jeremymill\\Documents\\temp\\ca.crt"
 }
 
 func isWindows() bool {

--- a/udp_rx.go
+++ b/udp_rx.go
@@ -141,7 +141,7 @@ func main() {
 		RootCAs:      rootCAs,
 		Certificates: []tls.Certificate{cer},
 	}
-	serverConf = udprxlib.GetServerConfig(rootCAs, cer)
+	serverConf = udprxlib.GetServerConfig(rootCAs, &cer)
 
 	// start listening on the UDP port in go routine
 	udpListenerDone := make(chan error, 1)

--- a/udprx_firewall/udprx_setfirewall.go
+++ b/udprx_firewall/udprx_setfirewall.go
@@ -41,7 +41,7 @@ func main() {
 		}
 		// try to parse to an int, continue if we can't
 		for _, netInterface := range interfaces {
-			if strings.HasPrefix(netInterface.Name, "lo") {
+			if !strings.HasPrefix(netInterface.Name, "lo") {
 				// iptables -I input -i eth0 -p udp --dport [port to REJECT] -j REJECT
 				var setArg string
 				if !*unsetFlag {

--- a/udprx_win_service/service.go
+++ b/udprx_win_service/service.go
@@ -137,12 +137,7 @@ func runService(name string, isDebug bool) {
 		Certificates: []tls.Certificate{cer},
 	}
 	// serverConf
-	serverConf = &tls.Config{
-		Certificates: []tls.Certificate{cer},
-		MinVersion:   tls.VersionTLS12,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    rootCAs,
-	}
+	serverConf = udprxlib.GetServerConfig(rootCAs, cer)
 	// config done
 	elog.Info(startingService, fmt.Sprintf("starting %s service", name))
 	run := svc.Run

--- a/udprx_win_service/service.go
+++ b/udprx_win_service/service.go
@@ -137,7 +137,7 @@ func runService(name string, isDebug bool) {
 		Certificates: []tls.Certificate{cer},
 	}
 	// serverConf
-	serverConf = udprxlib.GetServerConfig(rootCAs, cer)
+	serverConf = udprxlib.GetServerConfig(rootCAs, &cer)
 	// config done
 	elog.Info(startingService, fmt.Sprintf("starting %s service", name))
 	run := svc.Run

--- a/udprx_win_service/udprx_service.go
+++ b/udprx_win_service/udprx_service.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version is the current version of the application
-const Version = "A2331825AAA"
+const Version = "A2431825AAA"
 
 func usage(errmsg string) {
 	fmt.Fprintf(os.Stderr,

--- a/udprxlib/clientHostNameValidate.go
+++ b/udprxlib/clientHostNameValidate.go
@@ -1,0 +1,96 @@
+// Copyright 2018 Otis Elevator Company. All rights reserved.
+// Use of this source code is govered by the MIT license which
+// can be found in the LICENSE file.
+
+// Author: Jeremy Mill: jeremy.mill@otis.com
+
+// Otis udp_rx software has been designed to utilize information
+// security technology described in the Category 5 – Part 2 of the
+// Commerce Control List, within Part 774 of the Export Administration
+// Regulations (“EAR”)(15 CFR 774).  However, the Otis udp_rx software
+// has been made publicly available in accordance with Part 742.15(b)
+// of the EAR and is therefore not subject to U.S. export regulations.
+// Before downloading this software, be aware that the country in which
+// you are located may have restrictions related to the import, download,
+// possession, use and/or reexport of encryption items.  It is your
+// responsibility to comply with any applicable laws and regulations
+// pertaining the import, download, possession, use and/or reexport of
+// encryption items.
+
+// Package udprxlib is the driver for udprx
+package udprxlib
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// // ClientHostNameValidate performs a
+// func ClientHostNameValidate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+// 	//copied from the default options in src/crypto/tls/handshake_server.go, 680 (go 1.11)
+// 	opts := x509.VerifyOptions{
+// 		Roots:         c.config.ClientCAs,
+// 		CurrentTime:   c.config.time(),
+// 		Intermediates: x509.NewCertPool(),
+// 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+// 	}
+
+// 	roots := x509.NewCertPool()
+// 	for _, rawCert := range rawCerts {
+// 		cert, _ := x509.ParseCertificate(rawCert)
+// 		roots.AddCert(cert)
+// 	}
+// 	opts := x509.VerifyOptions{
+// 		Roots: roots,
+// 	}
+// 	_, err := cert.Verify(opts)
+// 	return err
+// }
+
+// func ClientHNValidate(helloInfo *tls.ClientHelloInfo) (*tls.Config, error) {
+// 	hi := helloInfo
+// 	serverConf := &tls.Config{
+// 		VerifyPeerCertificate: getClientValidator(hi, serverConf),
+// 	}
+// 	return serverConf, nil
+// }
+
+// GetClientValidator does a thing
+func getClientValidator(helloInfo *tls.ClientHelloInfo, c *tls.Config) func([][]byte, [][]*x509.Certificate) error {
+	log.Debug("AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH")
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		//copied from the default options in src/crypto/tls/handshake_server.go, 680 (go 1.11)
+		//but added DNSName
+		fmt.Println("EWOIFJOWEIFJWOIEWJFWOIEJF")
+		log.Debug("tls config in validator: ", c)
+		opts := x509.VerifyOptions{
+			Roots:         c.ClientCAs,
+			CurrentTime:   c.Time(),
+			Intermediates: x509.NewCertPool(),
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			DNSName:       helloInfo.Conn.RemoteAddr().String(),
+		}
+		_, err := verifiedChains[0][0].Verify(opts)
+		return err
+	}
+}
+
+// GetServerConfig returns a udp_rx TLS server configuration
+func GetServerConfig(rootCAs *x509.CertPool, cer tls.Certificate) *tls.Config {
+	serverConf := &tls.Config{
+		Certificates: []tls.Certificate{cer},
+		MinVersion:   tls.VersionTLS12,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    rootCAs,
+	}
+	serverConf.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+		serverConf := &tls.Config{
+			VerifyPeerCertificate: getClientValidator(hi, serverConf),
+		}
+		return serverConf, nil
+	}
+	return serverConf
+}


### PR DESCRIPTION
Client Certificate SANs were not previously validated by the server when a client connected. This PR fixes that issue and also fixes a bug the in udprx_firewall rules