### PR TITLE
Feature/dpd 2856 allow tls1 2 or 1 3

### DIFF
--- a/udprxlib/clientHostNameValidate.go
+++ b/udprxlib/clientHostNameValidate.go
@@ -47,14 +47,10 @@ func GetServerConfig(rcas *x509.CertPool, sc *tls.Certificate) *tls.Config {
 				GetCertificate: func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 					return serverCert, nil
 				},
-				MinVersion:            tls.VersionTLS12,
-				MaxVersion: tls.VersionTLS13,
-				PreferServerCipherSuites: true,
-				CurvePreferences: []tls.CurveID {
-					tls.X25519, tls.CurveP256, tls.CurveP384, tls.CurveP521,
-				},
-				ClientAuth:            tls.RequireAndVerifyClientCert,
-				ClientCAs:             rootCAs,
+				MinVersion:	tls.VersionTLS12,
+				MaxVersion:	tls.VersionTLS13,
+				ClientAuth:	tls.RequireAndVerifyClientCert,
+				ClientCAs:  rootCAs,
 				VerifyPeerCertificate: getClientValidator(hi),
 			}
 			return serverConf, nil

--- a/udprxlib/clientHostNameValidate.go
+++ b/udprxlib/clientHostNameValidate.go
@@ -48,6 +48,11 @@ func GetServerConfig(rcas *x509.CertPool, sc *tls.Certificate) *tls.Config {
 					return serverCert, nil
 				},
 				MinVersion:            tls.VersionTLS12,
+				MaxVersion: tls.VersionTLS13,
+				PreferServerCipherSuites: true,
+				CurvePreferences: []tls.CurveID {
+					tls.X25519, tls.CurveP256, tls.CurveP384, tls.CurveP521,
+				},
 				ClientAuth:            tls.RequireAndVerifyClientCert,
 				ClientCAs:             rootCAs,
 				VerifyPeerCertificate: getClientValidator(hi),


### PR DESCRIPTION
Updated to allow for TLS1.2 or TLS1.3.  Fallback to TLS1.2 if cannot establish TLS1.3